### PR TITLE
Add thread-id APNs support

### DIFF
--- a/lib/generators/rpush_migration_generator.rb
+++ b/lib/generators/rpush_migration_generator.rb
@@ -48,6 +48,7 @@ class RpushMigrationGenerator < Rails::Generators::Base
     add_rpush_migration('rpush_3_1_1_updates')
     add_rpush_migration('rpush_3_2_0_add_apns_p8')
     add_rpush_migration('rpush_3_2_4_updates')
+    add_rpush_migration('rpush_3_3_0_updates')
   end
 
   protected

--- a/lib/generators/templates/rpush_3_3_0_updates.rb
+++ b/lib/generators/templates/rpush_3_3_0_updates.rb
@@ -1,0 +1,9 @@
+class Rpush330Updates < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migration[5.0] : ActiveRecord::Migration
+  def self.up
+    add_column :rpush_notifications, :thread_id, :string, null: true
+  end
+
+  def self.down
+    remove_column :rpush_notifications, :thread_id
+  end
+end

--- a/lib/rpush/client/active_model/apns/notification.rb
+++ b/lib/rpush/client/active_model/apns/notification.rb
@@ -56,6 +56,7 @@ module Rpush
               json['aps']['sound'] = sound if sound
               json['aps']['category'] = category if category
               json['aps']['url-args'] = url_args if url_args
+              json['aps']['thread-id'] = thread_id if thread_id
 
               if data && data[MUTABLE_CONTENT_KEY]
                 json['aps']['mutable-content'] = 1

--- a/lib/rpush/client/redis/notification.rb
+++ b/lib/rpush/client/redis/notification.rb
@@ -45,6 +45,7 @@ module Rpush
         attribute :content_available, :boolean, default: false
         attribute :mutable_content, :boolean, default: false
         attribute :notification, :hash
+        attribute :thread_id, :string
 
         def app
           return nil unless app_id

--- a/spec/support/active_record_setup.rb
+++ b/spec/support/active_record_setup.rb
@@ -37,6 +37,7 @@ require 'generators/templates/rpush_3_1_0_add_pushy'
 require 'generators/templates/rpush_3_1_1_updates'
 require 'generators/templates/rpush_3_2_0_add_apns_p8'
 require 'generators/templates/rpush_3_2_4_updates'
+require 'generators/templates/rpush_3_3_0_updates'
 
 migrations = [
   AddRpush,
@@ -49,7 +50,8 @@ migrations = [
   Rpush310AddPushy,
   Rpush311Updates,
   Rpush320AddApnsP8,
-  Rpush324Updates
+  Rpush324Updates,
+  Rpush330Updates
 ]
 
 unless ENV['TRAVIS']

--- a/spec/unit/client/active_record/apns/notification_spec.rb
+++ b/spec/unit/client/active_record/apns/notification_spec.rb
@@ -309,3 +309,16 @@ describe Rpush::Client::ActiveRecord::Apns::Notification, "multi_json usage" do
     end
   end
 end if active_record?
+
+describe Rpush::Client::ActiveRecord::Apns::Notification, 'thread-id' do
+  let(:notification) { Rpush::Client::ActiveRecord::Apns::Notification.new }
+
+  it 'includes thread-id in the payload' do
+    notification.thread_id = 'THREAD-ID'
+    expect(notification.as_json['aps']['thread-id']).to eq 'THREAD-ID'
+  end
+
+  it 'does not include thread-id in the payload if not set' do
+    expect(notification.as_json['aps']).to_not have_key('thread-id')
+  end
+end if active_record?


### PR DESCRIPTION
Hello, this PR adds support for Apple Notification Services `thread-id` field.

